### PR TITLE
Fix to handle select multiple inputs

### DIFF
--- a/jquery.serializeJSON.js
+++ b/jquery.serializeJSON.js
@@ -91,6 +91,11 @@
     } else {
       if (key === '') {
         obj.push(value);
+      } else if(obj[key]) {  // check if entry already exists (i.e. select multiple)
+        if(typeof obj[key] == "string") {  //if only one entry we need to cast as array from a string
+          obj[key] = [obj[key]];
+        }
+        obj[key].push(value); //add additional values to array
       } else {
         obj[key] = value;
       }


### PR DESCRIPTION
If you use something such as:
     &lt;select name="category" multiple&gt;
       &lt;option value="a"&gt;a&lt;/option&gt;
       &lt;option value="b"&gt;b&lt;/option&gt;
       &lt;option value="c"&gt;c&lt;/option&gt;
     &lt;/select&gt;

And all 3 values are selected by the user then only the last one will be used as there is no check for an existing field. So the result will be:

```
 { category: "c" }
```

With this fix it checks for an existing category field and the result of the serialization is now:

```
{ category: ["a", "b", "c" ] } 
```
