### PR TITLE
Empty index with empty value not to overwrite existing element

### DIFF
--- a/jquery.serializeJSON.js
+++ b/jquery.serializeJSON.js
@@ -92,7 +92,7 @@
       if (key === '') {
         lastKey = obj.length - 1;
         lastElement = obj[obj.length - 1];
-        if (isObject(lastElement) && !lastElement[nextKey]) { // if nextKey is a new attribute in the last object element then set the new value in there.
+        if (isObject(lastElement) && typeof lastElement[nextKey] === 'undefined') { // if nextKey is a new attribute in the last object element then set the new value in there.
           key = lastKey;
         } else { // if the array does not have an object as last element, create one.
           obj.push({});

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -130,6 +130,12 @@ describe("$.deepSet", function () {
     expect(arr).toEqual([v, {foo: v, bar: v}, {bar: v}]);
   });
 
+  it("array push with empty index and empty value, not overwriting an existing element", function () {
+    deepSet(arr, ['', 'foo'], ''); //=> arr === [{foo: ''}]
+    deepSet(arr, ['', 'foo'], v);  //=> arr === [{foo: ''}, {foo: v}]
+    expect(arr).toEqual([{foo: ''}, {foo: v}]);
+  });
+
   it("should set all different nested values", function () {
     deepSet(obj, ['foo'], v);
     deepSet(obj, ['inn', 'foo'], v);


### PR DESCRIPTION
Hi,

I'm not sure it's by design or a bug, but I've made a patch anyway...

With a form like this:

```
<input type="text" name="p[][foo]" value="" />
<input type="text" name="p[][bar]" value="bar1" />

<input type="text" name="p[][foo]" value="foo2" />
<input type="text" name="p[][bar]" value="bar2" />
```

serializeJSON returns an object:

```
{
  p: [
    { foo: "foo2", bar: "bar1" },
    { foo: "", bar: "bar2" },
  ]
}
```

This is a bit unexpected result to me.

Although the first `p[][foo]` has a value of "empty string", serializeJSON overwrites the `foo` in the first object by the second `p[][foo]`, since it checks the absence of an element by `!lastElement[nextKey]` which results an empty string to true.
