### PR TITLE
disabled checkbox should not have unchecked value

### DIFF
--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -214,7 +214,7 @@
       if (opts == null) opts = {};
       f = $.serializeJSON;
 
-      selector = 'input[type=checkbox][name]:not(:checked)';
+      selector = 'input[type=checkbox][name]:not(:checked,[disabled])';
       $uncheckedCheckboxes = $form.find(selector).add($form.filter(selector));
       $uncheckedCheckboxes.each(function (i, el) {
         $el = $(el);

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -731,6 +731,14 @@ describe("$.serializeJSON", function () {
           }
         });
       });
+
+      it('does not serialize disabled checkboxes', function() {
+        $form = $('<form>');
+        $form.append($('<input type="checkbox" name="checkDisabled1" value="true" disabled/>'));
+        $form.append($('<input type="checkbox" name="checkDisabled2" value="true" disabled data-unchecked-value="NOPE"/>'));
+        obj = $form.serializeJSON({checkboxUncheckedValue: 'false'});
+        expect(obj).toEqual({});
+      });
     });
 
     describe('useIntKeysAsArrayIndex', function() {


### PR DESCRIPTION
Disabled elements should not be serialised. The selector for checkbox unchecked values was missing a disabled exclusion. This change prevents disabled checkboxes with default unchecked values from being serialized.