### PR TITLE
Fix data types with brackets in names

### DIFF
--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -187,8 +187,8 @@
     // Returns nil if none found. Returns the first data-value-type found if many inputs have the same name.
     tryToFindTypeFromDataAttr: function(name, $form) {
       var escapedName, selector, $input, typeFromDataAttr;
-      escapedName = name.replace(/(\[|\])/g, "\\$1"); // escape the [] in the name to be used as selector
-      selector = '[name="' + escapedName + '"]';
+      escapedName = name.replace(/(:|\.|\[|\]|\s)/g,'\\$1'); // every non-standard character need to be escaped by \\
+      selector = '[name=' + escapedName + ']';
       $input = $form.find(selector).add($form.filter(selector));
       typeFromDataAttr = $input.attr('data-value-type'); // NOTE: this returns only the first $input element if multiple are matched with the same name (i.e. an "array[]"). So, arrays with different element types specified through the data-value-type attr is not supported.
       return typeFromDataAttr || null;

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -525,6 +525,8 @@ describe("$.serializeJSON", function () {
       it("should set type if field name do not contain :type definition", function() {
         $form = $('<form>');
         $form.append($('<input type="text" name="fooData" data-value-type="alwaysBoo"   value="0"/>'));
+        $form.append($('<input type="text" name="fooDataWithBrackets[kokoszka]" data-value-type="alwaysBoo"   value="0"/>'));
+        $form.append($('<input type="text" name="fooDataWithBrackets[kokoszka i cos innego]" data-value-type="alwaysBoo"   value="0"/>'));
         $form.append($('<input type="text" name="foo:alwaysBoo" data-value-type="string"   value="0"/>'));
         $form.append($('<input type="text" name="notype" value="default type is :string"/>'));
         $form.append($('<input type="text" name="stringData" data-value-type="string"   value="data-value-type=string type overrides parsing options"/>'));
@@ -544,6 +546,10 @@ describe("$.serializeJSON", function () {
         });
 
         expect(obj).toEqual({
+          "fooDataWithBrackets": {
+            kokoszka: "Boo",
+            "kokoszka i cos innego": "Boo"
+          },
           "fooData": "Boo",
           "foo": "Boo",
           "notype": "default type is :string",


### PR DESCRIPTION
There was a problem with JQuery selector for escaped names including brackets