### PR TITLE
Feature: compact null arrays 

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Allowed options to change the default behavior:
   * **customTypes: {}**, define your own :types or override the default types. Defined as an object like `{ type: function(value){...} }`. For example: `{customTypes: {nullable: function(str){ return str || null; }}`.
   * **defaultTypes: {defaultTypes}**, in case you want to re-define all the :types. Defined as an object like `{ type: function(value){...} }`
   * **useIntKeysAsArrayIndex: true**, when using integers as keys (i.e. `<input name="foods[0]" value="banana">`), serialize as an array (`{"foods": ["banana"]}`) instead of an object (`{"foods": {"0": "banana"}`).
+  * **compactArrays: false**, when using integers as keys, reorder keys so there are no gaps (i.e. [0:"foo",5:"bar]
 
 More info about options usage in the sections below.
 
@@ -538,6 +539,7 @@ $('form').serializeJSON({useIntKeysAsArrayIndex: true});
 
 **Note**: this was the default behavior of serializeJSON before version 2. You can use this option for backwards compatibility.
 
+Use the option `compactArrays` to remove the undefined generated with useIntKeysAsArrayIndex.  This is helpful if you dynamically create and delete inputs but do not want a bunch of nulls in the resulting arrays and you may not be able to use `skipFalsyValuesForFields` or `skipFalsyValuesForTypes`.
 
 ## Defaults ##
 

--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -52,8 +52,8 @@
         }
       }
     });
-    if (opts.compactArray === true) {
-       f.compactArray(serializedObject);
+    if (opts.compactArrays === true) {
+       f.compactArrays(serializedObject);
     }
     return serializedObject;
   };
@@ -87,7 +87,7 @@
       },
 
       useIntKeysAsArrayIndex: false, // name="foo[2]" value="v" => {foo: [null, null, "v"]}, instead of {foo: ["2": "v"]}
-      compactArray: false
+      compactArrays: false
     },
 
     // Merge option defaults into the options
@@ -99,7 +99,7 @@
       defaultOptions = f.defaultOptions || {}; // defaultOptions
 
       // Make sure that the user didn't misspell an option
-      validOpts = ['checkboxUncheckedValue', 'parseNumbers', 'parseBooleans', 'parseNulls', 'parseAll', 'parseWithFunction', 'skipFalsyValuesForTypes', 'skipFalsyValuesForFields', 'customTypes', 'defaultTypes', 'useIntKeysAsArrayIndex', 'compactArray']; // re-define because the user may override the defaultOptions
+      validOpts = ['checkboxUncheckedValue', 'parseNumbers', 'parseBooleans', 'parseNulls', 'parseAll', 'parseWithFunction', 'skipFalsyValuesForTypes', 'skipFalsyValuesForFields', 'customTypes', 'defaultTypes', 'useIntKeysAsArrayIndex', 'compactArrays']; // re-define because the user may override the defaultOptions
       for (opt in options) {
         if (validOpts.indexOf(opt) === -1) {
           throw new  Error("serializeJSON ERROR: invalid option '" + opt + "'. Please use one of " + validOpts.join(', '));
@@ -124,7 +124,7 @@
         typeFunctions: $.extend({}, optWithDefault('defaultTypes'), optWithDefault('customTypes')),
 
         useIntKeysAsArrayIndex: optWithDefault('useIntKeysAsArrayIndex'),
-        compactArray: optWithDefault('compactArray')
+        compactArrays: optWithDefault('compactArrays')
       };
     },
 
@@ -346,8 +346,8 @@
 
     // Remove undefined values when using int as a key
     //
-    // compactArray([0: 'foo', 2: 'bar'])           // [0: 'foo', 1: 'bar']
-    compactArray: function (o) {
+    // compactArrays([0: 'foo', 2: 'bar'])           // [0: 'foo', 1: 'bar']
+    compactArrays: function (o) {
       var f = $.serializeJSON;
 
       if (f.isUndefined(o)) { throw new Error("ArgumentError: param 'o' expected to be an object or array, found undefined"); }
@@ -360,7 +360,7 @@
                 return e != null;
               });
             }
-            f.compactArray(o[property]);
+            f.compactArrays(o[property]);
           }
         }
       }


### PR DESCRIPTION
This feature will compact arrays, removing null/undefined entries.  

I needed this feature because I have a form that dynamically creates and deletes inputs.  Form input names are automatically generated.  Each index has several items under it.  A user can go on a clicking rampage adding multiple forms then delete all but a few.  This results in gaps, sometimes substantial.  Rather than iterate through every input looking to see if it needs to be renumbered it seemed more wise to just remove them after the fact (less DOM searching, slightly faster in my environment).

Example:

```html
<input name="foo[0][bar]">
<input name="foo[0][baz]">
<input name="foo[4][bar]">
<input name="foo[4][baz]">
```

would generate {foo: [[bar,baz],undefined,undefined,undefined,[bar,baz]]} with `useIntKeysAsArrayIndex` set to true.  

`skipFalsyValuesForFields` is not as elegant of a solution as an object containing 1..N elements to cover the spread of inputs created would need to be created.

`skipFalsyValuesForTypes` and a custom type is not a viable solution as I would need foo[N] with the type not foo[N][bar].

