### PR TITLE
Do not treat semicolon names as type

### DIFF
--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -193,7 +193,7 @@
     //   "foo[bar]:null" =>  {nameWithNoType: "foo[bar]", type: "null"}
     extractTypeAndNameWithNoType: function(name) {
       var match;
-      if (match = name.match(/(.*):([^:]+)$/)) {
+      if (match = name.match(/(.*):([A-Za-z]+)$/)) {
         return {nameWithNoType: match[1], type: match[2]};
       } else {
         return {nameWithNoType: name, type: null};


### PR DESCRIPTION
E.g. if the name is: `article[my:custom::key][active]`