### PR TITLE
Improvements to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Available options:
   * **skipFalsyValuesForFields: []**, skip given fields (by name) with falsy values. You can use `data-skip-falsy="true"` input attribute as well. Falsy values are determined after converting to a given type, note that `"0"` as `:string` (default) is still truthy, but `0` as `:number` is falsy.
   * **skipFalsyValuesForTypes: []**, skip given fields (by :type) with falsy values (i.e. `skipFalsyValuesForTypes: ["string", "number"]` would skip `""` for `:string` fields, and `0` for `:number` fields).
   * **customTypes: {}**, define your own `:type` functions. Defined as an object like `{ type: function(value){...} }`. For example: `{customTypes: {nullable: function(str){ return str || null; }}`. Custom types extend the **defaultTypes**.
+  * **defaultType: "string"**, fields that have no `:type` suffix and no `data-value-type` attribute are parsed with the `string` type function by default. This can be changed to use a different type like "number", or even a custom type function if defined in `customTypes`.
   * **disableSemicolonTypes: true**, do not parse input names as types, allowing field names to use semicolons. If this option is used, types can still be specified with the `data-value-type` attribute. For example `<input name="foo::bar" value="1" data-value-type="number">` will be parsed as a number.
 
 More details about these options in the sections below.

--- a/README.md
+++ b/README.md
@@ -135,20 +135,20 @@ Fields values are **string** by default. But can be parsed with types by appendi
 
 ```html
 <form>
-  <input type="text" name="default"          value=":string is the default, implicit type for all fields"/>
-  <input type="text" name="text:string"      value=":string type explicitly defined"/>
-  <input type="text" name="excluded:skip"    value="Use :skip to ignore this field in the result"/>
+  <input type="text" name="default"          value=":string is default"/>
+  <input type="text" name="text:string"      value="some text string"/>
+  <input type="text" name="excluded:skip"    value="ignored field because of type :skip"/>
 
-  <input type="text" name="numbers[1]:number"           value="1"/>
-  <input type="text" name="numbers[1.1]:number"         value="1.1"/>
-  <input type="text" name="numbers[other stuff]:number" value="other stuff"/>
+  <input type="text" name="numbers[1]:number"        value="1"/>
+  <input type="text" name="numbers[1.1]:number"      value="1.1"/>
+  <input type="text" name="numbers[other]:number"    value="other"/>
 
   <input type="text" name="bools[true]:boolean"      value="true"/>
   <input type="text" name="bools[false]:boolean"     value="false"/>
   <input type="text" name="bools[0]:boolean"         value="0"/>
 
-  <input type="text" name="nulls[null]:null"            value="null"/>
-  <input type="text" name="nulls[other stuff]:null"     value="other stuff"/>
+  <input type="text" name="nulls[null]:null"         value="null"/>
+  <input type="text" name="nulls[other]:null"        value="other"/>
 
   <input type="text" name="arrays[empty]:array"         value="[]"/>
   <input type="text" name="arrays[list]:array"          value="[1, 2, 3]"/>
@@ -163,13 +163,14 @@ $('form').serializeJSON();
 
 // returns =>
 {
-  "default": ":string is the default, implicit type for all fields",
-  "text": ":string type explicitly defined",
+  "default": ":string is the default",
+  "text": "some text string",
   // excluded:skip is ignored in the output
+
   "numbers": {
     "1": 1,
     "1.1": 1.1,
-    "other stuff": NaN, // <-- "other stuff" is parsed as NaN
+    "other": NaN, // <-- "other" is parsed as NaN
   },
   "bools": {
     "true": true,
@@ -178,7 +179,7 @@ $('form').serializeJSON();
   },
   "nulls": {
     "null": null, // <-- "false", "null", "undefined", "", "0"  are parsed as null
-    "other stuff": "other stuff"
+    "other": "other" // <-- if not null, the type is a string
   },
   "arrays": { // <-- uses JSON.parse
     "empty": [],
@@ -202,6 +203,9 @@ Types can also be specified with the attribute `data-value-type`, instead of add
 </form>
 ```
 
+If your field names contain semicolons (e.g. `name="article[my::key][active]"`) the last part after the semicolon will be confused as an invalid type. One way to avoid that is to explicitly append the type `:string` (e.g. `name="article[my::key][active]:string"`), or to use the attribute `data-value-type="string"`. Data attributes have precedence over `:type` name suffixes. It is also possible to disable parsing `:type` suffixes with the option `{disableSemicolonTypes: true}`.
+
+
 ### Custom Types
 
 You can define your own types or override the defaults with the `customTypes` option. For example:
@@ -210,7 +214,7 @@ You can define your own types or override the defaults with the `customTypes` op
 <form>
   <input type="text" name="scary:alwaysBoo" value="not boo"/>
   <input type="text" name="str:string"      value="str"/>
-  <input type="text" name="number:number"   value="5"/>
+  <input type="text" name="five:number"     value="5"/>
 </form>
 ```
 
@@ -221,16 +225,16 @@ $('form').serializeJSON({
       return "boo";
     },
     string: function(str) {
-      return str + " override";
+      return str + "-override";
     }
   }
 });
 
 // returns =>
 {
-  "scary": "boo",        // <-- parsed with type :alwaysBoo
-  "str": "str override", // <-- parsed with new type :string (instead of the default)
-  "number": 5,           // <-- parsed with the default :number type
+  "scary": "boo",        // <-- parsed with "alwaysBoo" function type
+  "str": "str-override", // <-- parsed with "string" function override (instead of the default)
+  "five": 5,             // <-- parsed with "number" function, one of the default types
 }
 ```
 
@@ -242,19 +246,19 @@ Options
 
 With no options, `.serializeJSON()` returns the same as a regular HTML form submission when serialized as Rack/Rails params. In particular:
 
-  * Values are always **strings** (unless appending a `:type` to the input names)
+  * Values are **strings** (unless appending a `:type` to the input name)
   * Unchecked checkboxes are ignored (as defined in the W3C rules for [successful controls](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2)).
   * Disabled elements are ignored (W3C rules)
   * Keys (input names) are always **strings** (nested params are objects by default)
 
-This can be altered with options:
+Available options:
 
   * **checkboxUncheckedValue: string**, string value used on unchecked checkboxes (otherwise those values are ignored). For example `{checkboxUncheckedValue: ""}`. If the value needs to be parsed (i.e. to a Boolean or Null) use a parse option (i.e. `parseBooleans: true`) or define the input with the `:boolean` or `:null` types.
   * **useIntKeysAsArrayIndex: true**, when using integers as keys (i.e. `<input name="foods[0]" value="banana">`), serialize as an array (`{"foods": ["banana"]}`) instead of an object (`{"foods": {"0": "banana"}`).
   * **skipFalsyValuesForFields: []**, skip given fields (by name) with falsy values. You can use `data-skip-falsy="true"` input attribute as well. Falsy values are determined after converting to a given type, note that `"0"` as `:string` (default) is still truthy, but `0` as `:number` is falsy.
   * **skipFalsyValuesForTypes: []**, skip given fields (by :type) with falsy values (i.e. `skipFalsyValuesForTypes: ["string", "number"]` would skip `""` for `:string` fields, and `0` for `:number` fields).
-  * **customTypes: {}**, define your own :types or override the default types. Defined as an object like `{ type: function(value){...} }`. For example: `{customTypes: {nullable: function(str){ return str || null; }}`.
-  * **defaultTypes: {defaultTypes}**, in case you want to re-define all the :types. Defined as an object like `{ type: function(value){...} }`
+  * **customTypes: {}**, define your own `:type` functions. Defined as an object like `{ type: function(value){...} }`. For example: `{customTypes: {nullable: function(str){ return str || null; }}`. Custom types extend the **defaultTypes**.
+  * **disableSemicolonTypes: true**, do not parse input names as types, allowing field names to use semicolons. If this option is used, types can still be specified with the `data-value-type` attribute. For example `<input name="foo::bar" value="1" data-value-type="number">` will be parsed as a number.
 
 More details about these options in the sections below.
 

--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -53,6 +53,7 @@
             }
 
             var typedValue = f.applyTypeFunc(rawName, rawValue, type, typeFunctions); // Parse type as string, number, etc.
+
             if (!typedValue && f.shouldSkipFalsy($form, rawName, name, type, opts)) {
                 return; // ignore falsy inputs if specified in the options
             }
@@ -161,7 +162,7 @@
             var parts = name.split(":");
             if (parts.length > 1) {
                 var t = parts.pop();
-                return [parts.join(""), t];
+                return [parts.join(":"), t];
             } else {
                 return [name, ""];
             }

--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -49,7 +49,7 @@
                 return; // ignore fields with type skip
             }
             if (!type) {
-                type = "string"; // default type is string
+                type = opts.defaultType; // "string" by default
             }
 
             var typedValue = f.applyTypeFunc(rawName, rawValue, type, typeFunctions); // Parse type as string, number, etc.
@@ -85,7 +85,8 @@
                 "array":   function(str) { return JSON.parse(str); },
                 "object":  function(str) { return JSON.parse(str); },
                 "skip":    null // skip is a special type used to ignore fields
-            }
+            },
+            defaultType: "string",
         },
 
         // Validate and set defaults
@@ -103,7 +104,8 @@
 
                 "disableSemicolonTypes",
                 "customTypes",
-                "defaultTypes"
+                "defaultTypes",
+                "defaultType"
             ];
             for (var opt in options) {
                 if (validOpts.indexOf(opt) === -1) {

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -442,15 +442,14 @@ describe("$.serializeJSON", function () {
         });
 
         describe("data-value-type attribute", function() {
-            it("should set type if field name does not contain :type definition", function() {
+            it("should set type and have precedence over the :type suffix", function() {
                 $form = $("<form>");
                 $form.append($("<input type=\"text\" name=\"fooData\" data-value-type=\"alwaysBoo\"   value=\"0\"/>"));
                 $form.append($("<input type=\"text\" name=\"fooDataWithBrackets[kokoszka]\" data-value-type=\"alwaysBoo\"   value=\"0\"/>"));
                 $form.append($("<input type=\"text\" name=\"fooDataWithBrackets[kokoszka i cos innego]\" data-value-type=\"alwaysBoo\"   value=\"0\"/>"));
-                $form.append($("<input type=\"text\" name=\"foo:alwaysBoo\" data-value-type=\"string\"   value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"foo:alwaysBoo\" data-value-type=\"string\"   value=\"string from data attr\"/>"));
+                $form.append($("<input type=\"text\" name=\"override::string\" data-value-type=\"boolean\"  value=\"boolean prevails\"/>"));
                 $form.append($("<input type=\"text\" name=\"notype\" value=\"default type is :string\"/>"));
-                $form.append($("<input type=\"text\" name=\"stringData\" data-value-type=\"string\"   value=\"data-value-type=string type overrides parsing options\"/>"));
-                $form.append($("<input type=\"text\" name=\"string:string\" data-value-type=\"boolean\"   value=\":string type overrides parsing options\"/>"));
                 $form.append($("<input type=\"text\" name=\"excludes\" data-value-type=\"skip\"   value=\"Use :skip to not include this field in the result\"/>"));
                 $form.append($("<input type=\"text\" name=\"numberData\" data-value-type=\"number\"   value=\"1\"/>"));
                 $form.append($("<input type=\"text\" name=\"numberData[A]\" data-value-type=\"number\"        value=\"1\"/>"));
@@ -471,10 +470,10 @@ describe("$.serializeJSON", function () {
                         "kokoszka i cos innego": "Boo"
                     },
                     "fooData": "Boo",
-                    "foo": "Boo",
+                    "foo:alwaysBoo": "string from data attr",
+                    "override::string": true,
                     "notype": "default type is :string",
-                    "stringData": "data-value-type=string type overrides parsing options",
-                    "string": ":string type overrides parsing options",
+                    // excludes was excluded because of type "skip"
                     "numberData": { A: 1, B: { C: 2 }, D: { E: { F: 3 } } },
                     "number": 1,
                     "selectNumber": 2
@@ -487,7 +486,6 @@ describe("$.serializeJSON", function () {
                         "<input type=\"text\" name=\"fooData\" data-value-type=\"alwaysBoo\"   value=\"0\"/>" +
                         "<input type=\"text\" name=\"foo:alwaysBoo\" data-value-type=\"string\"   value=\"0\"/>" +
                         "<input type=\"text\" name=\"notype\" value=\"default type is :string\"/>" +
-                        "<input type=\"text\" name=\"stringData\" data-value-type=\"string\"   value=\"data-value-type=string type overrides parsing options\"/>" +
                         "<input type=\"text\" name=\"number\" data-value-type=\"number\"   value=\"1\"/>"
                     );
 
@@ -499,9 +497,8 @@ describe("$.serializeJSON", function () {
 
                     expect(obj).toEqual({
                         "fooData": "Boo",
-                        "foo": "Boo",
+                        "foo:alwaysBoo": "0",
                         "notype": "default type is :string",
-                        "stringData": "data-value-type=string type overrides parsing options",
                         "number": 1
                     });
                 });
@@ -620,7 +617,7 @@ describe("$.serializeJSON", function () {
         describe("validateOptions", function() {
             it("should raise an error if the option is not one of the valid options", function() {
                 expect(function(){ $form.serializeJSON({invalidOption: true}); })
-                    .toThrow(new Error("serializeJSON ERROR: invalid option 'invalidOption'. Please use one of checkboxUncheckedValue, useIntKeysAsArrayIndex, skipFalsyValuesForTypes, skipFalsyValuesForFields, defaultTypes, customTypes"));
+                    .toThrow(new Error("serializeJSON ERROR: invalid option 'invalidOption'. Please use one of checkboxUncheckedValue, useIntKeysAsArrayIndex, skipFalsyValuesForTypes, skipFalsyValuesForFields, disableSemicolonTypes, customTypes, defaultTypes, defaultType"));
             });
         });
 
@@ -958,6 +955,107 @@ describe("$.serializeJSON", function () {
             expect(obj).toEqual({ "foo": "var", "empty": null});
         });
 
+        describe("defaultType", function() {
+            it("uses the specified type as default if no other type is defined", function() {
+                $form = $("<form>");
+                $form.append($("<input type=\"text\" name=\"notype\"           value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"foo:alwaysBoo\"    value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"string:string\"    value=\":string overrides default option\"/>"));
+                $form.append($("<input type=\"text\" name=\"excludes:skip\"    value=\"Use :skip to not include this field in the result\"/>"));
+                $form.append($("<input type=\"text\" name=\"fooData\"       data-value-type=\"alwaysBoo\"  value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"foostr::kaka\"  data-value-type=\"string\"     value=\"string from data attr\"/>"));
+
+                obj = $form.serializeJSON({
+                    defaultType: "number",
+                    customTypes: {
+                        alwaysBoo: function() { return "Boo"; }
+                    }
+                });
+
+                expect(obj).toEqual({
+                    "notype": 0, // parsed with "number", used as default type
+                    "foo": "Boo",
+                    "string": ":string overrides default option",
+                    // :skip type removes the field from the output
+                    "fooData": "Boo",
+                    "foostr::kaka": "string from data attr"
+                });
+            });
+
+            it("can be specified to be a custom type function", function() {
+                $form = $("<form>");
+                $form.append($("<input type=\"text\" name=\"notype\"           value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"string:string\"    value=\":string overrides default option\"/>"));
+
+                obj = $form.serializeJSON({
+                    defaultType: "alwaysBoo",
+                    customTypes: {
+                        alwaysBoo: function() { return "Boo"; }
+                    }
+                });
+
+                expect(obj).toEqual({
+                    "notype": "Boo", // parsed with "alwaysBoo", used as default type
+                    "string": ":string overrides default option",
+                });
+            });
+
+            it("raises an error if the type function is not specified", function() {
+                $form = $("<form>");
+                $form.append($("<input type=\"text\" name=\"fookey\" value=\"fooval\"/>"));
+                expect(function(){
+                    $form.serializeJSON({ defaultType: "not_a_valid_type" });
+                }).toThrow(new Error("serializeJSON ERROR: Invalid type not_a_valid_type found in input name 'fookey', please use one of string, number, boolean, null, array, object, skip"));
+            });
+        });
+
+
+        describe("disableSemicolonTypes", function() {
+            it("ignores type suffixes from input names", function() {
+                $form = $("<form>");
+                $form.append($("<input type=\"text\" name=\"foo\"              value=\"bar\"/>"));
+                $form.append($("<input type=\"text\" name=\"notype::foobar\"   value=\"foobar\"/>"));
+                $form.append($("<input type=\"text\" name=\"string:string\"    value=\"keeps full input name\"/>"));
+                $form.append($("<input type=\"text\" name=\"excludes:skip\"    value=\"not skip because is not parsed as a type\"/>"));
+
+                obj = $form.serializeJSON({ disableSemicolonTypes: true });
+
+                expect(obj).toEqual({
+                    "foo": "bar", // nothing special over here
+                    "notype::foobar": "foobar", // colons are no special now
+                    "string:string": "keeps full input name",
+                    "excludes:skip": "not skip because is not parsed as a type"
+                });
+            });
+            it("still respects default type function and data-value-type attributes if specified", function() {
+                $form = $("<form>");
+                $form.append($("<input type=\"text\" name=\"notype\"           value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"foo:alwaysBoo\"    value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"string:string\"    value=\"99\"/>"));
+                $form.append($("<input type=\"text\" name=\"excludes:skip\"    value=\"666\"/>"));
+                $form.append($("<input type=\"text\" name=\"fooData\"       data-value-type=\"alwaysBoo\"  value=\"0\"/>"));
+                $form.append($("<input type=\"text\" name=\"foostr::kaka\"  data-value-type=\"string\"     value=\"string from data attr\"/>"));
+
+                obj = $form.serializeJSON({
+                    disableSemicolonTypes: true,
+                    defaultType: "number",
+                    customTypes: {
+                        alwaysBoo: function() { return "Boo"; }
+                    }
+                });
+
+                expect(obj).toEqual({
+                    "notype": 0, // parsed with "number", used as default type
+                    "foo:alwaysBoo": 0,
+                    "string:string": 99,
+                    "excludes:skip": 666,
+
+                    "fooData": "Boo", // data-value-type still works to define other types
+                    "foostr::kaka": "string from data attr"
+                });
+            });
+        });
+
         describe("with defaultOptions", function() {
             var defaults = $.serializeJSON.defaultOptions;
             afterEach(function() {
@@ -1011,13 +1109,14 @@ describe("$.serializeJSON", function () {
     });
 });
 
-// extractTypeAndNameWithNoType
-describe("$.serializeJSON.extractTypeAndNameWithNoType", function() {
-    var extract = $.serializeJSON.extractTypeAndNameWithNoType;
+// splitType
+describe("$.serializeJSON.splitType", function() {
+    var splitType = $.serializeJSON.splitType;
     it("returns an object with type and nameWithNoType properties form the name with :type colon notation", function() {
-        expect(extract("foo")).toEqual({nameWithNoType: "foo", type: null});
-        expect(extract("foo:boolean")).toEqual({nameWithNoType: "foo", type: "boolean"});
-        expect(extract("foo[bar]:null")).toEqual({nameWithNoType: "foo[bar]", type: "null"});
+        expect(splitType("foo")).toEqual(["foo", ""]);
+        expect(splitType("foo:boolean")).toEqual(["foo", "boolean"]);
+        expect(splitType("foo[bar]:null")).toEqual(["foo[bar]", "null"]);
+        expect(splitType("foo[my::key]:string")).toEqual(["foo[my::key]", "string"]);
     });
 });
 

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -442,7 +442,7 @@ describe("$.serializeJSON", function () {
         });
 
         describe("data-value-type attribute", function() {
-            it("should set type if field name do not contain :type definition", function() {
+            it("should set type if field name does not contain :type definition", function() {
                 $form = $("<form>");
                 $form.append($("<input type=\"text\" name=\"fooData\" data-value-type=\"alwaysBoo\"   value=\"0\"/>"));
                 $form.append($("<input type=\"text\" name=\"fooDataWithBrackets[kokoszka]\" data-value-type=\"alwaysBoo\"   value=\"0\"/>"));
@@ -485,10 +485,10 @@ describe("$.serializeJSON", function () {
                 it("also works for matched inputs (not just forms) if they have the data-value-type attribute", function () {
                     var $inputs = $(
                         "<input type=\"text\" name=\"fooData\" data-value-type=\"alwaysBoo\"   value=\"0\"/>" +
-            "<input type=\"text\" name=\"foo:alwaysBoo\" data-value-type=\"string\"   value=\"0\"/>" +
-            "<input type=\"text\" name=\"notype\" value=\"default type is :string\"/>" +
-            "<input type=\"text\" name=\"stringData\" data-value-type=\"string\"   value=\"data-value-type=string type overrides parsing options\"/>" +
-            "<input type=\"text\" name=\"number\" data-value-type=\"number\"   value=\"1\"/>"
+                        "<input type=\"text\" name=\"foo:alwaysBoo\" data-value-type=\"string\"   value=\"0\"/>" +
+                        "<input type=\"text\" name=\"notype\" value=\"default type is :string\"/>" +
+                        "<input type=\"text\" name=\"stringData\" data-value-type=\"string\"   value=\"data-value-type=string type overrides parsing options\"/>" +
+                        "<input type=\"text\" name=\"number\" data-value-type=\"number\"   value=\"1\"/>"
                     );
 
                     obj = $inputs.serializeJSON({


### PR DESCRIPTION
Improve how types work with a bunch of changes.

 * Type suffix is parsed only after the last semicolon. Eg: `name="my[custom::key]:string"` will now get the type "string" from the last semicolon. Fixes issue #103 
 * Allow to disable type suffix with the option `disableSemicolonTypes: true`. Fixes issue #102 
 * Allow to use a different default type parsing function with the option `defaultType: "string"`. This allows more customization in case someone want's to recover some of the functionality that was provided by `parseNumbers` and similar options that were removed on PR #104 
 * If a `data-value-type` attribute is provided, then the type specified in the input field is ignored. This allows to specify types using only attributes, in which case semicolons in the field names are not used for parsing. This change is non-backwards compatible, giving precedence to the attributes instead of the type suffixes but it follows a better convention that was already used by other options in the plugin.