### PR TITLE
Reimplement jQuery's serializeArray with extended funcionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jquery.serializeJSON
 ====================
 
-Adds the method `.serializeJSON()` to [jQuery](http://jquery.com/) (or [Zepto](http://zeptojs.com/)) that serializes a form into a JavaScript Object, using the same format as the default Ruby on Rails request params.
+Adds the method `.serializeJSON()` to [jQuery](http://jquery.com/) to serializes a form into a JavaScript Object. Supports the same format for nested parameters that is used in Ruby on Rails.
 
 Install
 -------
@@ -40,7 +40,7 @@ $('form').serializeJSON();
 }
 ```
 
-Form input, textarea and select tags are supported. Nested attributes and arrays can be specified by naming fields with the syntax: `name="attr[nested][nested]"`.
+Nested attributes and arrays can be specified by naming fields with the syntax: `name="attr[nested][nested]"`.
 
 HTML form:
 ```html
@@ -124,8 +124,7 @@ var obj = $('form').serializeJSON();
 var jsonString = JSON.stringify(obj);
 ```
 
-The plugin implememtation relies on jQuery's [.serializeArray()](https://api.jquery.com/serializeArray/) method.
-This means that it only serializes the inputs supported by `.serializeArray()`, which follows the standard W3C rules for [successful controls](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2). In particular, the included elements **cannot be disabled** and must contain a **name attribute**. No submit button value is serialized since the form was not submitted using a button. And data from file select elements is not serialized.
+The plugin serializes the same inputs supported by [.serializeArray()](https://api.jquery.com/serializeArray/), following the standard W3C rules for [successful controls](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2). In particular, the included elements **cannot be disabled** and must contain a **name attribute**. No submit button value is serialized since the form was not submitted using a button. And data from file select elements is not serialized.
 
 
 Parse values with :types
@@ -203,12 +202,12 @@ Types can also be specified with the attribute `data-value-type`, instead of add
 </form>
 ```
 
-If your field names contain colons (e.g. `name="article[my::key][active]"`) the last part after the colon will be confused as an invalid type. One way to avoid that is to explicitly append the type `:string` (e.g. `name="article[my::key][active]:string"`), or to use the attribute `data-value-type="string"`. Data attributes have precedence over `:type` name suffixes. It is also possible to disable parsing `:type` suffixes with the option `{disableColonTypes: true}`.
+If your field names contain colons (e.g. `name="article[my::key][active]"`) the last part after the colon will be confused as an invalid type. One way to avoid that is to explicitly append the type `:string` (e.g. `name="article[my::key][active]:string"`), or to use the attribute `data-value-type="string"`. Data attributes have precedence over `:type` name suffixes. It is also possible to disable parsing `:type` suffixes with the option `{ disableColonTypes: true }`.
 
 
 ### Custom Types
 
-Use the `customTypes` option to provide your own type functions. For example:
+Use the `customTypes` option to provide your own parsing functions. The parsing functions receive the input name as a string, and the DOM elment of the serialized input.
 
 ```html
 <form>
@@ -221,19 +220,19 @@ Use the `customTypes` option to provide your own type functions. For example:
 ```javascript
 $('form').serializeJSON({
   customTypes: {
-    alwaysBoo: (str) => { return "boo"; },
+    alwaysBoo: (str, el) => { return "boo"; },
   }
 });
 
 // returns =>
 {
   "scary": "boo",  // <-- parsed with custom type "alwaysBoo"
-  "str": "str",    // <-- parsed with default type "string"
-  "five": 5,       // <-- parsed with default type "number"
+  "str": "str",
+  "five": 5,
 }
 ```
 
-The `customTypes` option can also include one of the `detaultTypes`, in which case it will override the default type:
+The provided `customTypes` can include one of the `detaultTypes` to override the default behavior:
 
 ```javascript
 $('form').serializeJSON({
@@ -251,7 +250,7 @@ $('form').serializeJSON({
 }
 ```
 
-The default types are defined in `$.serializeJSON.defaultOptions.defaultTypes`.
+Default types used by the plugin are defined in `$.serializeJSON.defaultOptions.defaultTypes`.
 
 
 Options
@@ -457,7 +456,7 @@ None of them did what I needed at the time `serializeJSON` was created. Factors 
 
  * Simple and small code base. The minimified version is < 1Kb.
  * Yet flexible enough with features like nested objects, unchecked-checkboxes and custom types.
- * Implemented on top of jQuery (or Zepto) `serializeArray`, that creates a JavaScript array of objects, ready to be encoded as a JSON string. It takes into account the W3C rules for [successful controls](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2), making `serializeJSON` as standard and stable as it can be.
+ * Implementation follows the same rules as the jQuery method `serializeArray`, that creates a JavaScript array of objects, ready to be encoded as a JSON string. Taking into account the W3C rules for [successful controls](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2) for better compatibility.
  * The format for the input field names is the same used by Rails (from [Rack::Utils.parse_nested_query](http://codefol.io/posts/How-Does-Rack-Parse-Query-Params-With-parse-nested-query)), that is successfully used by many backend systems and already well understood by many front end developers.
  * Exaustive test suite helps iterate on new releases and bugfixes with confidence.
  * Compatible with [bower](https://github.com/bower/bower), [zepto.js](http://zeptojs.com/) and pretty much every version of [jQuery](https://jquery.com/).
@@ -471,7 +470,7 @@ Contributions are awesome. Feature branch *pull requests* are the preferred meth
 Changelog
 ---------
 
- * *3.2.0* (draft): ... TODO: update comment: https://github.com/marioizquierdo/jquery.serializeJSON/issues/67
+ * *3.2.0* (Dec 31, 2020): (Pre). Reimplement jQuery's serializeArray function, with the ability to include unchecked checkboxes, and returning the DOM element. This allows to simplify the code, fixing an issue with repeated input names used for arrays (Fixes #67), and allows custom type functions to receive the DOM elemnt (Fixes #109).
  * *3.1.1* (Dec 30, 2020): Update #114 (Allow to use new versions of jQuery by avoiding calls to the deprecated method `jQuery.isArray`).
  * *3.1.1* (Nov 09, 2020): Bugfix #110 (Allow unindexed arrays with multiple levels of nested objects).
  * *3.1.0* (Sep 13, 2020): Rename option `disableColonTypes` that was mistakenly named `disableSemicolonTypes`. Fix typos in README.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $('form').serializeJSON();
 }
 ```
 
-Form input, textarea and select tags are supported. Nested attributes and arrays can be specified by using the `attr[nested][nested]` syntax.
+Form input, textarea and select tags are supported. Nested attributes and arrays can be specified by naming fields with the syntax: `name="attr[nested][nested]"`.
 
 HTML form:
 ```html
@@ -114,7 +114,7 @@ $('#my-profile').serializeJSON();
 }
 ```
 
-The `serializeJSON` function returns a JavaScript object, not a JSON String. The plugin should probably have been called `serializeObject` or similar, but those plugins already existed.
+The `serializeJSON` function returns a JavaScript object, not a JSON String. The plugin should probably have been called `serializeObject` or similar, but that plugin name was already taken.
 
 To convert into a JSON String, use the `JSON.stringify` method, that is available on all major [new browsers](http://caniuse.com/json).
 If you need to support very old browsers, just include the [json2.js](https://github.com/douglascrockford/JSON-js) polyfill (as described on [stackoverfow](http://stackoverflow.com/questions/191881/serializing-to-json-in-jquery)).
@@ -471,7 +471,8 @@ Contributions are awesome. Feature branch *pull requests* are the preferred meth
 Changelog
 ---------
 
- * *3.1.1* (Dev 30, 2020): Update #114 (Allow to use new versions of jQuery by avoiding calls to the deprecated method `jQuery.isArray`).
+ * *3.2.0* (draft): ... TODO: update comment: https://github.com/marioizquierdo/jquery.serializeJSON/issues/67
+ * *3.1.1* (Dec 30, 2020): Update #114 (Allow to use new versions of jQuery by avoiding calls to the deprecated method `jQuery.isArray`).
  * *3.1.1* (Nov 09, 2020): Bugfix #110 (Allow unindexed arrays with multiple levels of nested objects).
  * *3.1.0* (Sep 13, 2020): Rename option `disableColonTypes` that was mistakenly named `disableSemicolonTypes`. Fix typos in README.
  * *3.0.0* (Sep 06, 2020): Improve types (PR #105) and remove parsing options (PR #104). The type system with `:type` suffixes, `data-value-type` attributes, and a combination of the options `customTypes`, `disableColonTypes` and `defaultType`, are safer and easier to use than the previous options `parseNumbers`, `parseAll`, etc. Thanks [Laykou](https://github.com/Laykou) for suggesting [PR #102] that pointed the problems of inputs with colons in their names.

--- a/jquery.serializejson.js
+++ b/jquery.serializejson.js
@@ -29,10 +29,10 @@
     $.fn.serializeJSON = function (options) {
         var f = $.serializeJSON;
         var $form = this; // NOTE: the set of matched elements is most likely a form, but it could also be a group of inputs
-        var opts = f.setupOpts(options); // validate and apply defaults
+        var opts = f.setupOpts(options); // validate options and apply defaults
         var typeFunctions = $.extend({}, opts.defaultTypes, opts.customTypes);
 
-        // Make a list with {name, value, el} for each input element.
+        // Make a list with {name, value, el} for each input element
         var serializedArray = f.serializeArray($form, opts);
 
         // Convert the serializedArray into a serializedObject with nested keys
@@ -169,7 +169,7 @@
             if (val == null) {
                 val = opts.checkboxUncheckedValue;
             }
-            return val
+            return val;
         },
 
         // Parse value with type function
@@ -193,14 +193,11 @@
             } else {
                 return [name, ""];
             }
-            return typeFunc(valStr, el);
         },
 
         // Check if this input should be skipped when it has a falsy value,
         // depending on the options to skip values by name or type, and the data-skip-falsy attribute.
         shouldSkipFalsy: function(name, nameSansType, type, el, opts) {
-            var f = $.serializeJSON;
-
             var skipFromDataAttr = $(el).attr("data-skip-falsy");
             if (skipFromDataAttr != null) {
                 return skipFromDataAttr !== "false"; // any value is true, except the string "false"

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -907,7 +907,8 @@ describe("$.serializeJSON", function() {
         describe("customTypes", function() {
             it("serializes value according to custom function without disturbing default types", function() {
                 $form = form([
-                    inputText("foo:alwaysBoo",    "0"),
+                    inputText("foo:alwaysBoo",   "0"),
+
                     inputText("notype",           "default type is :string"),
                     inputText("string:string",    ":string type overrides parsing options"),
                     inputText("excludes:skip",    "Use :skip to not include this field in the result"),
@@ -938,6 +939,7 @@ describe("$.serializeJSON", function() {
 
                 expect(obj).toEqual({
                     "foo": "Boo",
+
                     "notype": "default type is :string",
                     "string": ":string type overrides parsing options",
                     // :skip type removes the field from the output
@@ -963,6 +965,31 @@ describe("$.serializeJSON", function() {
                         "empty": {},
                         "not empty": {"my": "stuff"}
                     }
+                });
+            });
+
+            it("type functions receive the value and the DOM element of the field that is being parsed", function() {
+                $form = form([
+                    inputText("foo1:withXoxo", "luv"),
+                    inputText("foo2:withXoxo", "luv").attr("data-Xoxo", "CustomPassedXoxo"),
+                    inputText("foo3:multiply", "3").attr("data-multiply", "5"),
+                ]);
+                obj = $form.serializeJSON({
+                    customTypes: {
+                        withXoxo: function(val, el) {
+                            var xoxo = $(el).attr("data-Xoxo") || "Xoxo";
+                            return val + xoxo;
+                        },
+                        multiply: function(val, el) {
+                            var mult = $(el).attr("data-multiply");
+                            return Number(val) * Number(mult);
+                        },
+                    }
+                });
+                expect(obj).toEqual({
+                    "foo1": "luvXoxo",
+                    "foo2": "luvCustomPassedXoxo",
+                    "foo3": 15 // 3 * 5
                 });
             });
 

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -825,16 +825,25 @@ describe("$.serializeJSON", function() {
                 });
             });
 
-            it("does not work on a nested list of objects", function() {
+            it("works on a nested list of objects", function() {
                 $form = form([
                     inputCheckbox("answers[][correct]:boolean", "true").attr("data-unchecked-value", "false"),
                     inputText("answers[][text]", "Blue"),
 
                     inputCheckbox("answers[][correct]:boolean", "true").attr("data-unchecked-value", "false"),
                     inputText("answers[][text]", "Green"),
-                ]);
 
-                expect(function(){$form.serializeJSON();}).toThrow(); // it throws a descriptive error for the user
+                    inputCheckbox("answers[][correct]:boolean", "true").attr("data-unchecked-value", "false").prop("checked", true),
+                    inputText("answers[][text]", "Red"),
+                ]);
+                obj = $form.serializeJSON({checkboxUncheckedValue: "false"});
+                expect(obj).toEqual({
+                    answers: [
+                        {correct: false, text: "Blue"},
+                        {correct: false, text: "Green"},
+                        {correct: true, text: "Red"},
+                    ],
+                });
             });
 
             it("does not serialize disabled checkboxes", function() {


### PR DESCRIPTION
Instead of relying on jQuery's [serializeArray](https://api.jquery.com/serializeArray/) method, the plugin now re-implements its own method with the exact same functionality, but extending its behavior to include the DOM element in the returned list of objects. This allows the plugin to handle multiple inputs with the same name, which is common when defining arrays. Fixes #67.

Functions provided as custom types (`customTypes` option) now receive an optional second argument with the DOM element. This allows for more powerful integrations between serializeJSON and other plugins. This implements the proposal on issue #109.

In addition, the extended serializeArray handles unchecked checkboxes with the plugin options, which simplifies the code and allows using unchecked checkboxes for array elements (with the same input name, e.g. "myarray[]").